### PR TITLE
fix for docker hostname error

### DIFF
--- a/commands
+++ b/commands
@@ -38,7 +38,7 @@ case "$1" in
       echo "" > "$SERVICE_ROOT/ENV"
     fi
     SERVICE_NAME=$(get_service_name "$SERVICE")
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/rabbitmq" --hostname $SERVICE -e RABBITMQ_DEFAULT_USER=$SERVICE -e RABBITMQ_DEFAULT_PASS=$password -e RABBITMQ_DEFAULT_VHOST=$SERVICE --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=rabbitmq "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/rabbitmq" -e RABBITMQ_DEFAULT_USER=$SERVICE -e RABBITMQ_DEFAULT_PASS=$password -e RABBITMQ_DEFAULT_VHOST=$SERVICE --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=rabbitmq "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"


### PR DESCRIPTION
This should fix the: 

```
$ dokku RABBITMQ_IMAGE_VERSION=3.5.4-management rabbitmq:create rabbitmq-3_5_4
-----> Starting container
docker: invalid hostname format for --hostname: rabbitmq-3_5_4.
See 'docker run --help'.

```

Error.

@justin-yesware 
